### PR TITLE
refactor(header): 확장형 검색 헤더 최종 정리

### DIFF
--- a/frontend/src/components/search/ExpandedHeaderSearch.jsx
+++ b/frontend/src/components/search/ExpandedHeaderSearch.jsx
@@ -1,0 +1,21 @@
+import SearchForm from "./SearchForm";
+
+export default function ExpandedHeaderSearch({
+  area,
+  initialActive,
+  state,
+  onSubmit,
+}) {
+  return (
+    <div className="max-w-5xl mx-auto px-4 pb-4">
+      <div className="bg-white rounded-2xl">
+        <SearchForm
+          state={state}
+          onSubmit={onSubmit}
+          area={area}
+          initialActive={initialActive}
+        />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/search/GuestsPopover.jsx
+++ b/frontend/src/components/search/GuestsPopover.jsx
@@ -19,7 +19,7 @@ export default function GuestsPopover({ open, onClose, people, setPeople }) {
   return (
     <div
       ref={ref}
-      className="absolute top-12 right-0 z-50 w-[320px] rounded-2xl bg-white shadow p-6 focus:border-slate-500"
+      className="absolute top-14 right-0 z-50 w-[330px] border border-slate-200 rounded-2xl bg-white p-6 pr-8 focus:border-slate-500"
     >
       <div className="flex items-center justify-between gap-4">
         <div className="min-w-[160px]">
@@ -32,7 +32,7 @@ export default function GuestsPopover({ open, onClose, people, setPeople }) {
           <button
             type="button"
             onClick={dec}
-            className="w-8 h-8 rounded-full shadow text-lg leading-none cursor-pointer"
+            className="w-8 h-8 rounded-full border border-slate-200 text-lg leading-none cursor-pointer"
             aria-label="감소"
           >
             −
@@ -43,7 +43,7 @@ export default function GuestsPopover({ open, onClose, people, setPeople }) {
           <button
             type="button"
             onClick={inc}
-            className="w-8 h-8 rounded-full shadow text-lg leading-none cursor-pointer"
+            className="w-8 h-8 rounded-full border border-slate-200 text-lg leading-none cursor-pointer"
             aria-label="증가"
           >
             +

--- a/frontend/src/components/search/SearchForm.jsx
+++ b/frontend/src/components/search/SearchForm.jsx
@@ -1,16 +1,17 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { DateRange } from "react-date-range";
 import { format } from "date-fns";
 import { ko } from "date-fns/locale";
 import "react-date-range/dist/styles.css";
 import "react-date-range/dist/theme/default.css";
 import GuestsPopover from "./GuestsPopover";
+import { formatRangeKR } from "../../utils/dateText";
 
 export default function SearchForm({
-  state, // useHomeSearchState() 리턴값
-  onSubmit, // (payload) => void
-  variant = "hero", // "hero" | "compact"
-  area = "domestic", // "domestic" | "overseas"
+  state,
+  onSubmit,
+  area = "domestic",
+  initialActive = "place",
 }) {
   const {
     keyword,
@@ -26,34 +27,19 @@ export default function SearchForm({
 
   const [openGuests, setOpenGuests] = useState(false);
 
-  const wrapCls =
-    variant === "compact"
-      ? "grid grid-cols-[1.2fr_1fr_1fr_auto] items-center rounded-full border border-slate-300 overflow-hidden"
-      : "grid grid-cols-1 sm:grid-cols-5 gap-2 bg-[#FFFFFF]";
+  useEffect(() => {
+    if (initialActive === "date") {
+      setOpen(true);
+      setOpenGuests(false);
+    } else if (initialActive === "guests") {
+      setOpen(false);
+      setOpenGuests(true);
+    } else {
+      setOpen(false);
+      setOpenGuests(false);
+    }
+  }, [initialActive, setOpen]);
 
-  const inputCls =
-    variant === "compact"
-      ? "h-11 px-4 text-sm outline-none border border-transparent focus:border-blue-500 focus:ring-2 focus:ring-blue-300 bg-[#EBEBEB] focus:bg-white rounded-lg"
-      : "col-span-2 p-3 rounded-lg bg-[#EBEBEB] outline-none border border-transparent focus:ring-1 focus:ring-black-300 focus:bg-white";
-
-  const dateBtnCls =
-    variant === "compact"
-      ? "h-11 px-4 text-left border-l border-slate-200 hover:bg-gray-50 cursor-pointer"
-      : "w-full p-3 rounded-lg text-left bg-[#EBEBEB] cursor-pointer outline-none border border-transparent focus:ring-1 focus:ring-black-300 focus:bg-white";
-
-  const peopleCls =
-    variant === "compact"
-      ? "h-11 px-4 border-l border-slate-200 cursor-pointer text-left"
-      : "w-full p-3 rounded-lg cursor-pointer text-left bg-[#EBEBEB] outline-none border border-transparent focus:ring-1 focus:ring-black-300 focus:bg-white";
-  const btnCls =
-    variant === "compact"
-      ? "h-11 mx-2 my-2 px-5 rounded-full bg-blue-500 text-white font-semibold disabled:bg-blue-300"
-      : "rounded-lg p-3 text-white bg-blue-500 hover:bg-blue-600 disabled:bg-blue-300";
-
-  const nights = Math.max(
-    1,
-    (range[0].endDate - range[0].startDate) / 86400000 // 1000*60*60*24
-  );
   const isValid = keyword.trim().length > 0;
 
   const submit = () => {
@@ -64,14 +50,14 @@ export default function SearchForm({
       checkIn: format(range[0].startDate, "yyyy-MM-dd"),
       checkOut: format(range[0].endDate, "yyyy-MM-dd"),
       people,
-      rooms: "1",
+      rooms: 1,
     });
   };
 
   return (
-    <div className={wrapCls}>
+    <div className="grid grid-cols-1 sm:grid-cols-5 gap-2 bg-white">
       <input
-        className={inputCls}
+        className="col-span-2 p-3 rounded-lg bg-gray-100 outline-none focus:ring-1 focus:ring-black-300 focus:bg-white"
         type="text"
         placeholder="도시를 입력하세요 예) 서울 도쿄 부산"
         value={keyword}
@@ -85,15 +71,15 @@ export default function SearchForm({
             setOpen(!open);
             setOpenGuests(false);
           }}
-          className={dateBtnCls}
+          className="w-full p-3 rounded-lg text-left bg-gray-100 cursor-pointer outline-none focus:ring-1 focus:ring-black-300 focus:bg-white whitespace-nowrap overflow-hidden text-ellipsis"
         >
-          {format(range[0].startDate, "MM.dd")} -{" "}
-          {format(range[0].endDate, "MM.dd")} ({nights}박)
+          {formatRangeKR(range[0].startDate, range[0].endDate)}
         </button>
+
         {open && (
           <div
             ref={pickerRef}
-            className="absolute top-12 z-50 bg-white border rounded-xl shadow-xl"
+            className="absolute top-15 border border-slate-200 rounded-xl text-left bg-gray-100 outline-none focus:ring-1 focus:ring-black-300 focus:bg-white"
           >
             <DateRange
               ranges={range}
@@ -109,17 +95,19 @@ export default function SearchForm({
           </div>
         )}
       </div>
+
       <div className="relative">
         <button
           type="button"
           onClick={() => {
-            setOpenGuests((v) => !v);
             setOpen(false);
+            setOpenGuests((v) => !v);
           }}
-          className={peopleCls}
+          className="w-full p-3 rounded-lg text-left bg-gray-100 outline-none focus:ring-1 focus:ring-black-300 focus:bg-white"
         >
           인원 {people}
         </button>
+
         <GuestsPopover
           open={openGuests}
           onClose={() => setOpenGuests(false)}
@@ -127,8 +115,14 @@ export default function SearchForm({
           setPeople={setPeople}
         />
       </div>
-      <button onClick={submit} disabled={!isValid} className={btnCls}>
-        {variant === "compact" ? "검색" : "숙소 찾기"}
+
+      <button
+        type="button"
+        onClick={submit}
+        disabled={!isValid}
+        className="rounded-lg p-3 text-white bg-blue-500 hover:bg-blue-600 disabled:bg-blue-300 cursor-pointer"
+      >
+        검색
       </button>
     </div>
   );

--- a/frontend/src/components/search/SummaryBar.jsx
+++ b/frontend/src/components/search/SummaryBar.jsx
@@ -1,0 +1,31 @@
+export default function SummaryBar({ summary, onOpen }) {
+  // summary = { place, dateText, guestsText }
+  const cellBase =
+    "flex-1 h-11 px-2 flex items-center hover:bg-gray-200 rounded-lg transition cursor-pointer text-sm font-bold";
+
+  return (
+    <div className="ml-16 max-w-300 flex items-center bg-gray-100 border-transparent rounded-md">
+      <button
+        type="button"
+        className={cellBase}
+        onClick={() => onOpen("place")}
+      >
+        <span className="px-4 py-2 whitespace-nowrap truncate">
+          {summary.place}
+        </span>
+      </button>
+      <button type="button" className={cellBase} onClick={() => onOpen("date")}>
+        <span className="px-4 py-2 whitespace-nowrap">{summary.dateText}</span>
+      </button>
+      <button
+        type="button"
+        className={cellBase}
+        onClick={() => onOpen("guests")}
+      >
+        <span className="px-4 py-2 whitespace-nowrap">
+          {summary.guestsText}
+        </span>
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/contexts/HeaderContext.jsx
+++ b/frontend/src/contexts/HeaderContext.jsx
@@ -1,34 +1,39 @@
-import { createContext, useContext, useState, useMemo } from "react";
+import {
+  createContext,
+  useContext,
+  useState,
+  useMemo,
+  useCallback,
+} from "react";
 
 const HeaderContext = createContext(null);
 
-export function HeaderProvider({ children }) {
-  const [state, setState] = useState({
-    mode: "default", // "default" | "detail"
-    title: "",
-    location: "",
-    checkIn: "",
-    checkOut: "",
-    adults: 2,
-    rooms: 1,
-  });
+const DEFAULT = {
+  mode: "default", // "default" | "detail"
+  title: "",
+  location: "",
+  checkIn: "",
+  checkOut: "",
+  dateText: "", // "09.20 토 - 09.21 일 (1박)" 같은 요약 텍스트
+  people: 2,
+  rooms: 1,
+};
 
+export function HeaderProvider({ children }) {
+  const [header, setHeader] = useState(DEFAULT);
+
+  // setHeader/ resetHeader를 콜백으로 고정해 렌더 사이클 안정화
+  const mergeHeader = useCallback(
+    (next) => setHeader((cur) => ({ ...cur, ...next })),
+    []
+  );
+
+  const resetHeader = useCallback(() => setHeader(DEFAULT), []);
+
+  // value도 메모이즈해서 매 렌더마다 새 객체 안 만들도록
   const value = useMemo(
-    () => ({
-      header: state,
-      setHeader: (next) => setState((cur) => ({ ...cur, ...next })),
-      resetHeader: () =>
-        setState({
-          mode: "default",
-          title: "",
-          location: "",
-          checkIn: "",
-          checkOut: "",
-          people: 2,
-          rooms: 1,
-        }),
-    }),
-    [state]
+    () => ({ header, setHeader: mergeHeader, resetHeader }),
+    [header, mergeHeader, resetHeader]
   );
 
   return (

--- a/frontend/src/hooks/useResultsHeader.js
+++ b/frontend/src/hooks/useResultsHeader.js
@@ -1,0 +1,65 @@
+import { useEffect, useMemo } from "react";
+import { useSearchParams } from "react-router-dom";
+import { useHeader } from "../contexts/HeaderContext";
+import { formatRangeKR, nightsBetween } from "../utils/dateText";
+
+function toSlug(s = "") {
+  return String(s)
+    .trim()
+    .replace(/\s+/g, " ")
+    .toLowerCase()
+    .replace(/\s/g, "-");
+}
+
+/**
+ * @param {"domestic"|"overseas"} type   결과 페이지 타입
+ * @param {string} locationLabel         헤더 서브라인 (예: "국내 숙소", "해외 숙소")
+ */
+export default function useResultsHeader(type, locationLabel) {
+  const [params] = useSearchParams();
+  const { setHeader, resetHeader } = useHeader();
+
+  // URL 파라미터
+  const city = params.get("city") || (type === "overseas" ? "도쿄" : "서울");
+  const checkIn = params.get("checkIn") || "2025-10-14";
+  const checkOut = params.get("checkOut") || "2025-10-15";
+  const people = Number(params.get("people") || params.get("adults") || 2);
+  const rooms = Number(params.get("rooms") || 1);
+
+  // 파생값
+  const start = useMemo(() => new Date(checkIn), [checkIn]);
+  const end = useMemo(() => new Date(checkOut), [checkOut]);
+  const nights = useMemo(() => nightsBetween(start, end), [start, end]);
+  const dateText = useMemo(
+    () => formatRangeKR(start, end, nights),
+    [start, end, nights]
+  );
+  const citySlug = useMemo(() => toSlug(city), [city]);
+
+  // 헤더 요약 즉시 반영
+  useEffect(() => {
+    setHeader({
+      mode: "detail",
+      title: city,
+      location: locationLabel,
+      checkIn,
+      checkOut,
+      people,
+      rooms,
+      dateText,
+    });
+    return () => resetHeader();
+  }, [
+    city,
+    checkIn,
+    checkOut,
+    people,
+    rooms,
+    dateText,
+    locationLabel,
+    setHeader,
+    resetHeader,
+  ]);
+
+  return { city, citySlug, checkIn, checkOut, people, rooms, nights };
+}

--- a/frontend/src/layouts/Header.jsx
+++ b/frontend/src/layouts/Header.jsx
@@ -1,22 +1,125 @@
-import { Link } from "react-router-dom";
+import { Link, useNavigate, useLocation } from "react-router-dom";
+import { useMemo, useState, useEffect } from "react";
 import { useHeader } from "../contexts/HeaderContext";
+import useHomeSearchState from "../hooks/useHomeSearchState";
+import SummaryBar from "../components/search/SummaryBar";
+import ExpandedHeaderSearch from "../components/search/ExpandedHeaderSearch";
+import { formatRangeKR, nightsBetween } from "../utils/dateText";
 
 export default function Header() {
-  const { header } = useHeader();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { header, setHeader } = useHeader();
+  const state = useHomeSearchState();
 
-  if (header.mode === "detail") {
-    return (
-      <header className="p-4 h-20 flex items-center border-b border-slate-200">
-        <Link to="/" className="ml-8 text-4xl font-bold">
+  const [expanded, setExpanded] = useState(false);
+  const [initialActive, setInitialActive] = useState("place");
+  const [area, setArea] = useState("domestic");
+
+  // 확장 허용 경로: /domestic, /overseas, /accommodation/:id
+  const canExpand = /^(\/domestic|\/overseas|\/accommodation\/)/.test(
+    location.pathname
+  );
+
+  // 경로가 바뀌어 확장 허용이 아니면 자동으로 닫기
+  useEffect(() => {
+    if (!canExpand && expanded) setExpanded(false);
+  }, [canExpand, expanded]);
+
+  // ESC 키로 닫기
+  useEffect(() => {
+    if (!expanded) return;
+    const onKey = (e) => e.key === "Escape" && setExpanded(false);
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [expanded]);
+
+  const summary = useMemo(
+    () => ({
+      place: header.title || "어디로",
+      dateText: header.dateText || "날짜",
+      guestsText:
+        header.people && header.rooms
+          ? `성인 ${header.people} · 객실 ${header.rooms}`
+          : "인원",
+    }),
+    [header]
+  );
+
+  const openExpanded = (tab) => {
+    if (!canExpand) return; // 홈 등에서는 열리지 않음
+    setInitialActive(tab);
+    setExpanded(true);
+  };
+
+  const handleSubmit = (payload) => {
+    const params = new URLSearchParams({
+      city: payload.city,
+      checkIn: payload.checkIn,
+      checkOut: payload.checkOut,
+      people: String(payload.people),
+      rooms: String(payload.rooms ?? 1),
+    }).toString();
+
+    // 현재 선택된 탭에 따라 경로 전환
+    navigate({ pathname: `/${area}`, search: `?${params}` }, { replace: true });
+
+    // 요약바 즉시 반영
+    const start = new Date(payload.checkIn);
+    const end = new Date(payload.checkOut);
+    const nights = nightsBetween(start, end);
+    const dateText = formatRangeKR(start, end, nights);
+
+    setHeader({
+      mode: "detail",
+      title: payload.city,
+      checkIn: payload.checkIn,
+      checkOut: payload.checkOut,
+      people: payload.people,
+      rooms: payload.rooms ?? 1,
+      dateText,
+    });
+
+    setExpanded(false);
+  };
+
+  return (
+    <header className="border-b border-slate-200 bg-white relative z-50">
+      <div className="p-4 h-20 flex items-center">
+        <Link to="/" className="ml-8 text-3xl font-bold">
           Stay
         </Link>
 
-        <div className="ml-32 min-w-0 bg-gray-100 p-3 rounded-lg">
-          <div className="text-sm font-semibold text-gray-600 truncate">
-            {header.title} | {header.checkIn} ~ {header.checkOut} | 인원{" "}
-            {header.people}, 객실 {header.rooms}
-          </div>
-        </div>
+        {!expanded && header.mode === "detail" && (
+          <SummaryBar summary={summary} onOpen={openExpanded} />
+        )}
+
+        {expanded && canExpand && (
+          <nav className="flex gap-6 text-lg font-semibold ml-auto">
+            <button
+              type="button"
+              className={`pb-1 cursor-pointer ${
+                area === "domestic"
+                  ? "text-blue-500 border-b-2 border-blue-500"
+                  : "text-gray-600"
+              }`}
+              onClick={() => setArea("domestic")}
+            >
+              국내 숙소
+            </button>
+            <button
+              type="button"
+              className={`pb-1 cursor-pointer ${
+                area === "overseas"
+                  ? "text-blue-500 border-b-2 border-blue-500"
+                  : "text-gray-600"
+              }`}
+              onClick={() => setArea("overseas")}
+            >
+              해외 숙소
+            </button>
+          </nav>
+        )}
 
         <Link
           to="/login"
@@ -24,22 +127,34 @@ export default function Header() {
         >
           로그인/회원가입
         </Link>
-      </header>
-    );
-  }
+      </div>
 
-  // 기본 헤더
-  return (
-    <header className="p-4 h-20 flex items-center border-b border-slate-200">
-      <Link to="/" className="ml-8 text-4xl font-bold">
-        Stay
-      </Link>
-      <Link
-        to="/login"
-        className="ml-auto mr-8 border px-4 py-2 border-blue-500 rounded-lg text-blue-500 font-semibold"
-      >
-        로그인/회원가입
-      </Link>
+      {/* 확장 영역: 허용 경로 + 열린 상태일 때만 렌더 */}
+      {expanded && canExpand && (
+        <div
+          className="transition-[max-height] top-12 max-h-[720px]"
+          style={{ overflow: "visible" }}
+        >
+          <div className="relative z-50">
+            <ExpandedHeaderSearch
+              area={area}
+              initialActive={initialActive}
+              state={state}
+              onSubmit={handleSubmit}
+            />
+          </div>
+        </div>
+      )}
+
+      {/* 바깥 클릭 닫기: 허용 경로 + 열린 상태일 때만 */}
+      {expanded && canExpand && (
+        <button
+          type="button"
+          aria-label="close expanded header"
+          onClick={() => setExpanded(false)}
+          className="fixed left-0 right-0 bottom-0 top-20 z-40 bg-transparent"
+        />
+      )}
     </header>
   );
 }

--- a/frontend/src/pages/DomesticResultsPage.jsx
+++ b/frontend/src/pages/DomesticResultsPage.jsx
@@ -1,49 +1,15 @@
-import { useSearchParams } from "react-router-dom";
-import { useEffect } from "react";
-import { useHeader } from "../contexts/HeaderContext";
-
-import ResultHeader from "../components/ResultHeader";
+import useResultsHeader from "../hooks/useResultsHeader";
 import Filters from "../components/Filters";
 import SortBar from "../components/SortBar";
 import ResultList from "../components/ResultList";
 import KakaoMap from "../components/KakaoMap";
 
-function toSlug(s = "") {
-  return String(s)
-    .trim()
-    .replace(/\s+/g, " ")
-    .toLowerCase()
-    .replace(/\s/g, "-");
-}
-
 export default function DomesticResultsPage() {
-  const [params] = useSearchParams();
-  const { setHeader, resetHeader } = useHeader();
-
-  const city = params.get("city") || "서울";
-  const citySlug = toSlug(city);
-  const checkIn = params.get("checkIn") || "2025-10-14";
-  const checkOut = params.get("checkOut") || "2025-10-15";
-  const adults = Number(params.get("adults") || 2);
-  const rooms = Number(params.get("rooms") || 1);
-
-  useEffect(() => {
-    setHeader({
-      mode: "detail",
-      title: city, // 상단 굵은 제목
-      location: "국내 숙소", // 서브 라인 (원하면 시/도 등으로 변경)
-      checkIn,
-      checkOut,
-      adults,
-      rooms,
-    });
-    return () => resetHeader();
-  }, [city, checkIn, checkOut, adults, rooms]);
+  const { city, citySlug } = useResultsHeader("domestic", "국내 숙소");
 
   return (
     <section className="max-w-7xl mx-auto p-6">
       <div className="grid grid-cols-1 lg:grid-cols-[320px_1fr] gap-6">
-        {/* 왼쪽 사이드: 지도 -> 필터 */}
         <aside className="order-2 lg:order-1">
           <KakaoMap
             className="w-full h-[180px] rounded-lg border border-slate-200"
@@ -55,7 +21,6 @@ export default function DomesticResultsPage() {
           </div>
         </aside>
 
-        {/* 오른쪽 결과 영역 */}
         <section className="order-1 lg:order-2">
           <SortBar total={120} />
           <ResultList type="domestic" city={citySlug} cityLabel={city} />

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -17,7 +17,7 @@ export default function Home() {
       city: p.city,
       checkIn: p.checkIn,
       checkOut: p.checkOut,
-      adults: p.adults,
+      people: p.people,
       rooms: p.rooms,
     }).toString();
     nav(`/${p.base}?${qs}`);
@@ -37,7 +37,7 @@ export default function Home() {
                 전주 한옥부터 서울 호텔까지 여행할 땐 Stay
               </h1>
 
-              <div className="mt-6 rounded-2xl border-slate-200 bg-white/95 backdrop-blur p-6 pt-4 shadow-xl">
+              <div className="mt-6 rounded-2xl border-slate-200 bg-white backdrop-blur p-6 pt-4 shadow-xl">
                 {/* 국내 해외 선택 */}
                 <div className="mb-3 flex flex-wrap">
                   {categories.map((cat) => (

--- a/frontend/src/pages/OverseasResultsPage.jsx
+++ b/frontend/src/pages/OverseasResultsPage.jsx
@@ -1,50 +1,15 @@
-import { useSearchParams } from "react-router-dom";
-import { useEffect } from "react";
-import { useHeader } from "../contexts/HeaderContext";
-
-import ResultHeader from "../components/ResultHeader";
+import useResultsHeader from "../hooks/useResultsHeader";
 import Filters from "../components/Filters";
 import SortBar from "../components/SortBar";
 import ResultList from "../components/ResultList";
 import KakaoMap from "../components/KakaoMap";
 
-function toSlug(s = "") {
-  return String(s)
-    .trim()
-    .replace(/\s+/g, " ")
-    .toLowerCase()
-    .replace(/\s/g, "-");
-}
-
 export default function OverseasResultsPage() {
-  const [params] = useSearchParams();
-  const { setHeader, resetHeader } = useHeader();
-
-  const city = params.get("city") || "도쿄"; // ← 사용자 입력 그대로 표시용
-  const citySlug = toSlug(city); // ← 내부용
-  const checkIn = params.get("checkIn") || "2025-10-14";
-  const checkOut = params.get("checkOut") || "2025-10-15";
-  const adults = Number(params.get("adults") || 2);
-  const rooms = Number(params.get("rooms") || 1);
-
-  useEffect(() => {
-    setHeader({
-      mode: "detail",
-      title: city,
-      location: "해외 숙소",
-      checkIn,
-      checkOut,
-      adults,
-      rooms,
-    });
-    return () => resetHeader();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [city, checkIn, checkOut, adults, rooms]);
+  const { city, citySlug } = useResultsHeader("overseas", "해외 숙소");
 
   return (
     <section className="max-w-7xl mx-auto p-6">
       <div className="grid grid-cols-1 lg:grid-cols-[320px_1fr] gap-6">
-        {/* 왼쪽 사이드: 지도 -> 필터 */}
         <aside className="order-2 lg:order-1">
           <KakaoMap
             className="w-full h-[180px] rounded-lg border border-slate-200"
@@ -52,14 +17,13 @@ export default function OverseasResultsPage() {
             query={city}
           />
           <div className="mt-4">
-            <Filters type="domestic" />
+            <Filters type="overseas" />
           </div>
         </aside>
 
-        {/* 오른쪽 결과 영역 */}
         <section className="order-1 lg:order-2">
           <SortBar total={120} />
-          <ResultList type="domestic" city={citySlug} cityLabel={city} />
+          <ResultList type="overseas" city={citySlug} cityLabel={city} />
         </section>
       </div>
     </section>

--- a/frontend/src/utils/dateText.js
+++ b/frontend/src/utils/dateText.js
@@ -1,0 +1,15 @@
+import { format } from "date-fns";
+import { ko } from "date-fns/locale";
+
+export function nightsBetween(start, end) {
+  return Math.max(1, Math.round((end - start) / 86400000));
+}
+
+export function formatRangeKR(start, end, nights) {
+  const n = nights ?? nightsBetween(start, end);
+  return `${format(start, "MM.dd EEE", { locale: ko })} - ${format(
+    end,
+    "MM.dd EEE",
+    { locale: ko }
+  )} (${n}박)`;
+}


### PR DESCRIPTION
- SearchOverlay 제거, ExpandedHeaderSearch로 일원화
- HeaderContext people/adults 필드 통일 (people만 사용)
- SummaryBar 내부 불필요한 summary 재정의 코드 제거
- Domestic/OverseasResultsPage import 정리 (ResultHeader 제거)
- 불필요한 스타일 클래스 일부 정리