### PR TITLE
style: 인기 숙소 탭 테두리 스타일 개선

### DIFF
--- a/frontend/src/components/accommodation/HotAccommodation.jsx
+++ b/frontend/src/components/accommodation/HotAccommodation.jsx
@@ -130,7 +130,7 @@ export default function Hot() {
                 "my-1 cursor-pointer rounded-full px-4 py-2 text-sm whitespace-nowrap transition-all duration-200",
                 selected
                   ? "bg-slate-900 text-white"
-                  : "border-1 text-black-700 hover:bg-slate-200",
+                  : "border border-gray-200 text-black-700 hover:bg-slate-200",
               ].join(" ")}
             >
               {tab.name}


### PR DESCRIPTION
- border-1에서 border-gray-200으로 변경
- 비선택 탭의 시각적 구분성 향상