### PR TITLE
feat: JWT 기반 소셜 로그인 API 구현

### DIFF
--- a/backend/auth-test.http
+++ b/backend/auth-test.http
@@ -1,0 +1,71 @@
+### 1. 소셜 로그인 - 구글 (신규 가입)
+POST http://localhost:8080/api/auth/login
+Content-Type: application/json
+
+{
+  "provider": "GOOGLE",
+  "socialId": "google-real-12345",
+  "email": "realuser@gmail.com",
+  "name": "실제유저",
+  "socialEmail": "realuser@gmail.com",
+  "profileImageUrl": "https://example.com/profile.jpg"
+}
+
+###
+
+### 2. 소셜 로그인 - 네이버
+POST http://localhost:8080/api/auth/login
+Content-Type: application/json
+
+{
+  "provider": "NAVER",
+  "socialId": "naver-12345",
+  "email": "naveruser@naver.com",
+  "name": "네이버유저",
+  "socialEmail": "naveruser@naver.com",
+  "profileImageUrl": "https://example.com/naver-profile.jpg"
+}
+
+###
+
+### 3. 소셜 로그인 - 카카오
+POST http://localhost:8080/api/auth/login
+Content-Type: application/json
+
+{
+  "provider": "KAKAO",
+  "socialId": "kakao-12345",
+  "email": "kakaouser@kakao.com",
+  "name": "카카오유저",
+  "socialEmail": "kakaouser@kakao.com",
+  "profileImageUrl": "https://example.com/kakao-profile.jpg"
+}
+
+###
+
+### 4. Access Token 재발급
+# 먼저 위의 로그인 API를 호출해서 refreshToken을 받은 후
+# 아래 {여기에_리프레시_토큰_붙여넣기} 부분에 붙여넣기
+POST http://localhost:8080/api/auth/refresh
+Content-Type: application/json
+
+{
+  "refreshToken": "{여기에_리프레시_토큰_붙여넣기}"
+}
+
+###
+
+### 5. 같은 계정으로 다시 로그인 (기존 회원 확인)
+POST http://localhost:8080/api/auth/login
+Content-Type: application/json
+
+{
+  "provider": "GOOGLE",
+  "socialId": "google-real-12345",
+  "email": "realuser@gmail.com",
+  "name": "실제유저",
+  "socialEmail": "realuser@gmail.com",
+  "profileImageUrl": "https://example.com/profile.jpg"
+}
+
+###

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -27,6 +27,9 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.5'
+    runtimeOnly   'io.jsonwebtoken:jjwt-impl:0.12.5'
+    runtimeOnly   'io.jsonwebtoken:jjwt-jackson:0.12.5'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/backend/src/main/java/com/stay/config/DataSourceConfig.java
+++ b/backend/src/main/java/com/stay/config/DataSourceConfig.java
@@ -3,22 +3,35 @@ package com.stay.config;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
 
 import javax.sql.DataSource;
 
 /**
  * DataSource 수동 설정
  *
- * - 자동 설정이 실패할 때 수동으로 빈 생성
  * - HikariCP: 현업에서 가장 많이 쓰는 커넥션 풀
  * - @Primary: 여러 DataSource가 있을 때 기본으로 사용할 것 지정
+ * - @Profile("!test"): 테스트 프로필에서는 이 설정을 비활성화 (H2 등으로 대체)
  */
 @Slf4j
 @Configuration
+@Profile("!test")
+
 public class DataSourceConfig {
+
+    @Value("${DB_URL}")
+    private String dbUrl;
+
+    @Value("${DB_USERNAME}")
+    private String dbUsername;
+
+    @Value("${DB_PASSWORD}")
+    private String dbPassword;
 
     @Bean
     @Primary
@@ -27,10 +40,14 @@ public class DataSourceConfig {
         log.info("DataSource 수동 생성 시작...");
 
         try {
+            if (dbUrl == null || dbUrl.isBlank()) {
+                throw new IllegalArgumentException("DB_URL이 비어 있습니다. 환경 변수를 확인하세요.");
+            }
+
             HikariConfig config = new HikariConfig();
-            config.setJdbcUrl(System.getenv("DB_URL"));
-            config.setUsername(System.getenv("DB_USERNAME"));
-            config.setPassword(System.getenv("DB_PASSWORD"));
+            config.setJdbcUrl(dbUrl);
+            config.setUsername(dbUsername);
+            config.setPassword(dbPassword);
             config.setDriverClassName("com.mysql.cj.jdbc.Driver");
 
             // 커넥션 풀 설정
@@ -39,8 +56,6 @@ public class DataSourceConfig {
             config.setConnectionTimeout(30000);
             config.setIdleTimeout(600000);
             config.setMaxLifetime(1800000);
-
-            // 커넥션 테스트 쿼리
             config.setConnectionTestQuery("SELECT 1");
 
             HikariDataSource dataSource = new HikariDataSource(config);
@@ -52,10 +67,10 @@ public class DataSourceConfig {
             return dataSource;
 
         } catch (Exception e) {
-            log.error("=".repeat(50));
+            log.info("=".repeat(50));
             log.error("❌ DataSource 생성 실패!");
             log.error("에러: {}", e.getMessage(), e);
-            log.error("=".repeat(50));
+            log.info("=".repeat(50));
             throw new RuntimeException("DataSource 생성 실패", e);
         }
     }

--- a/backend/src/main/java/com/stay/config/JwtProperties.java
+++ b/backend/src/main/java/com/stay/config/JwtProperties.java
@@ -1,0 +1,35 @@
+package com.stay.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+/**
+ * JWT 설정 정보
+ * application-dev.yml의 jwt.* 설정을 읽어옴
+ */
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "jwt")
+public class JwtProperties {
+
+    /**
+     * JWT 서명에 사용할 비밀키
+     * HS256 알고리즘 기준 최소 256비트(32바이트) 필요
+     */
+    private String secret;
+
+    /**
+     * Access Token 유효기간 (밀리초)
+     * 기본값: 1시간 (3600000ms)
+     */
+    private Long accessTokenValidity;
+
+    /**
+     * Refresh Token 유효기간 (밀리초)
+     * 기본값: 7일 (604800000ms)
+     */
+    private Long refreshTokenValidity;
+}

--- a/backend/src/main/java/com/stay/domain/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/stay/domain/auth/controller/AuthController.java
@@ -1,0 +1,128 @@
+package com.stay.domain.auth.controller;
+
+import com.stay.domain.auth.dto.JwtTokenResponse;
+import com.stay.domain.auth.dto.TokenRefreshRequest;
+import com.stay.domain.auth.service.AuthService;
+import com.stay.domain.member.dto.SocialLoginRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * 인증 컨트롤러
+ *
+ * API 엔드포인트:
+ * - POST /api/auth/login : 소셜 로그인
+ * - POST /api/auth/refresh : Access Token 재발급
+ *
+ * 왜 필요한가?
+ * - 프론트엔드가 백엔드에 인증 요청을 보낼 창구
+ * - HTTP 요청/응답 처리
+ * - 비즈니스 로직은 Service에 위임 (Controller는 얇게!)
+ */
+@Slf4j
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    /**
+     * 소셜 로그인 API
+     *
+     * POST /api/auth/login
+     *
+     * 요청 Body:
+     * {
+     *   "provider": "GOOGLE",
+     *   "socialId": "google-123456",
+     *   "email": "user@gmail.com",
+     *   "name": "홍길동",
+     *   "socialEmail": "user@gmail.com",
+     *   "profileImageUrl": "https://..."
+     * }
+     *
+     * 응답:
+     * {
+     *   "accessToken": "eyJhbGc...",
+     *   "refreshToken": "eyJhbGc...",
+     *   "tokenType": "Bearer",
+     *   "expiresIn": 3600
+     * }
+     *
+     * 프론트엔드는 이렇게 사용:
+     * 1. 소셜 로그인 버튼 클릭
+     * 2. OAuth 인증 완료 후 소셜 제공자에서 정보 받기
+     * 3. 이 API로 정보 전달
+     * 4. 받은 JWT 토큰을 localStorage에 저장
+     * 5. 이후 API 호출 시 Header에 "Bearer {accessToken}" 추가
+     */
+    @PostMapping("/login")
+    public ResponseEntity<JwtTokenResponse> login(
+            @RequestBody SocialLoginRequest request
+    ) {
+        log.info("소셜 로그인 요청 - provider: {}, email: {}",
+                request.provider(), request.email());
+
+        try {
+            JwtTokenResponse response = authService.socialLogin(request);
+
+            log.info("소셜 로그인 성공 - email: {}", request.email());
+            return ResponseEntity.ok(response);
+
+        } catch (Exception e) {
+            log.error("소셜 로그인 실패", e);
+
+            // 에러 처리는 나중에 GlobalExceptionHandler로 통합 예정
+            // 지금은 간단하게 500 에러 반환
+            return ResponseEntity.internalServerError().build();
+        }
+    }
+
+    /**
+     * Access Token 재발급 API
+     *
+     * POST /api/auth/refresh
+     *
+     * 요청 Body:
+     * {
+     *   "refreshToken": "eyJhbGc..."
+     * }
+     *
+     * 응답:
+     * {
+     *   "accessToken": "새로운토큰...",
+     *   "refreshToken": "새로운리프레시토큰...",
+     *   "tokenType": "Bearer",
+     *   "expiresIn": 3600
+     * }
+     *
+     * 언제 사용?
+     * - 프론트엔드에서 API 요청 시 401 Unauthorized 받으면
+     * - 저장된 Refresh Token으로 이 API 호출
+     * - 새로운 Access Token 받아서 다시 요청
+     */
+    @PostMapping("/refresh")
+    public ResponseEntity<JwtTokenResponse> refresh(
+            @RequestBody TokenRefreshRequest request
+    ) {
+        log.info("토큰 재발급 요청");
+
+        try {
+            JwtTokenResponse response = authService.refreshAccessToken(request.refreshToken());
+
+            log.info("토큰 재발급 성공");
+            return ResponseEntity.ok(response);
+
+        } catch (IllegalArgumentException e) {
+            log.error("토큰 재발급 실패: {}", e.getMessage());
+            return ResponseEntity.badRequest().build();
+
+        } catch (Exception e) {
+            log.error("토큰 재발급 실패", e);
+            return ResponseEntity.internalServerError().build();
+        }
+    }
+}

--- a/backend/src/main/java/com/stay/domain/auth/dto/JwtTokenResponse.java
+++ b/backend/src/main/java/com/stay/domain/auth/dto/JwtTokenResponse.java
@@ -1,0 +1,36 @@
+package com.stay.domain.auth.dto;
+
+import lombok.Builder;
+
+/**
+ * JWT 토큰 응답 DTO
+ *
+ * 왜 필요한가?
+ * - 로그인 성공 시 프론트엔드에게 토큰을 전달하기 위해
+ * - Record를 사용해서 불변 객체로 만듦 (실수로 변경 방지)
+ *
+ * 프론트엔드는 이 응답을 받아서:
+ * - accessToken을 localStorage에 저장
+ * - API 요청 시 Header에 "Bearer {accessToken}" 형태로 전달
+ * - refreshToken도 저장해서 액세스 토큰 갱신에 사용
+ */
+@Builder
+public record JwtTokenResponse(
+        String accessToken,
+        String refreshToken,
+        String tokenType,      // "Bearer"
+        Long expiresIn         // 액세스 토큰 만료 시간 (초 단위)
+) {
+    /**
+     * 편의 생성 메서드
+     * Bearer 타입으로 고정하고, 만료 시간을 자동 계산
+     */
+    public static JwtTokenResponse of(String accessToken, String refreshToken, Long accessTokenValidity) {
+        return JwtTokenResponse.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .tokenType("Bearer")
+                .expiresIn(accessTokenValidity / 1000)  // 밀리초 -> 초 변환
+                .build();
+    }
+}

--- a/backend/src/main/java/com/stay/domain/auth/dto/TokenRefreshRequest.java
+++ b/backend/src/main/java/com/stay/domain/auth/dto/TokenRefreshRequest.java
@@ -1,0 +1,18 @@
+package com.stay.domain.auth.dto;
+
+/**
+ * 토큰 재발급 요청 DTO
+ *
+ * 왜 필요한가?
+ * - Access Token이 만료되면 Refresh Token으로 새로 발급받아야 함
+ * - 프론트엔드가 보내는 Refresh Token을 받기 위한 DTO
+ *
+ * Record를 사용한 이유:
+ * - 불변 객체 (한번 생성하면 변경 불가)
+ * - 간결한 코드 (생성자, getter 자동 생성)
+ * - DTO는 데이터 전달만 하므로 Record가 적합
+ */
+public record TokenRefreshRequest(
+        String refreshToken
+) {
+}

--- a/backend/src/main/java/com/stay/domain/auth/service/AuthService.java
+++ b/backend/src/main/java/com/stay/domain/auth/service/AuthService.java
@@ -1,0 +1,128 @@
+package com.stay.domain.auth.service;
+
+import com.stay.config.JwtProperties;
+import com.stay.domain.auth.dto.JwtTokenResponse;
+import com.stay.domain.auth.util.JwtUtil;
+import com.stay.domain.member.dto.SocialLoginRequest;
+import com.stay.domain.member.entity.Member;
+import com.stay.domain.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 인증 서비스
+ *
+ * 왜 필요한가?
+ * - Member 도메인: 회원 정보 관리 (가입, 조회, 포인트 등)
+ * - Auth 도메인: 인증/인가 처리 (로그인, JWT 발급)
+ *
+ * 역할 분리로 각 도메인의 책임이 명확해짐 (단일 책임 원칙)
+ *
+ * 트랜잭션 전략:
+ * - 클래스 레벨에 @Transactional(readOnly = true) 제거!
+ * - 각 메서드별로 필요한 트랜잭션 설정 적용
+ * - socialLogin()은 회원 가입(INSERT)이 필요하므로 readOnly 불가
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final MemberService memberService;
+    private final JwtUtil jwtUtil;
+    private final JwtProperties jwtProperties;
+
+    /**
+     * 소셜 로그인 처리 및 JWT 발급
+     *
+     * 흐름:
+     * 1. MemberService를 통해 소셜 로그인 처리 (회원가입 or 로그인)
+     * 2. 로그인 성공한 회원 정보로 JWT 토큰 생성
+     * 3. 프론트엔드에 토큰 응답
+     *
+     * @param request 소셜 로그인 정보 (provider, socialId, email 등)
+     * @return JWT 토큰 (accessToken, refreshToken)
+     *
+     * 트랜잭션 전략:
+     * - @Transactional 없음: MemberService.socialLogin()에서 이미 트랜잭션 관리
+     * - JWT 생성은 트랜잭션과 무관한 작업
+     * - 불필요한 트랜잭션 중복 방지
+     */
+    public JwtTokenResponse socialLogin(SocialLoginRequest request) {
+        log.info("소셜 로그인 처리 시작 - provider: {}, email: {}",
+                request.provider(), request.email());
+
+        // 1. 회원 가입 or 로그인 처리 (MemberService에서 @Transactional 처리됨)
+        Member member = memberService.socialLogin(request);
+
+        // 2. JWT 토큰 생성 (트랜잭션 불필요)
+        String accessToken = jwtUtil.generateAccessToken(member.getId(), member.getEmail());
+        String refreshToken = jwtUtil.generateRefreshToken(member.getId());
+
+        log.info("JWT 토큰 발급 완료 - memberId: {}, email: {}",
+                member.getId(), member.getEmail());
+
+        // 3. 응답 DTO 생성
+        return JwtTokenResponse.of(
+                accessToken,
+                refreshToken,
+                jwtProperties.getAccessTokenValidity()
+        );
+    }
+
+    /**
+     * Access Token 재발급
+     *
+     * 흐름:
+     * 1. Refresh Token 유효성 검증
+     * 2. Refresh Token에서 회원 ID 추출
+     * 3. 새로운 Access Token 발급
+     *
+     * @param refreshToken Refresh Token
+     * @return 새로운 JWT 토큰
+     *
+     * 왜 필요한가?
+     * - Access Token은 1시간이면 만료됨
+     * - 사용자가 계속 로그인 상태를 유지하려면 토큰 재발급 필요
+     * - Refresh Token으로 새로운 Access Token을 받아옴
+     *
+     * 트랜잭션 전략:
+     * - @Transactional(readOnly = true): 회원 조회만 하므로 읽기 전용
+     * - 읽기 전용 트랜잭션은 성능 최적화에 도움
+     */
+    @Transactional(readOnly = true)
+    public JwtTokenResponse refreshAccessToken(String refreshToken) {
+        log.info("Access Token 재발급 요청");
+
+        // 1. Refresh Token 검증
+        if (!jwtUtil.validateToken(refreshToken)) {
+            throw new IllegalArgumentException("유효하지 않은 Refresh Token입니다.");
+        }
+
+        // 2. Refresh Token 타입 확인
+        String tokenType = jwtUtil.getTokenType(refreshToken);
+        if (!"refresh".equals(tokenType)) {
+            throw new IllegalArgumentException("Refresh Token이 아닙니다.");
+        }
+
+        // 3. 회원 ID 추출
+        Long memberId = jwtUtil.getMemberIdFromToken(refreshToken);
+
+        // 4. 회원 정보 조회 (읽기 전용 트랜잭션으로 조회)
+        Member member = memberService.findById(memberId);
+
+        // 5. 새로운 토큰 생성
+        String newAccessToken = jwtUtil.generateAccessToken(member.getId(), member.getEmail());
+        String newRefreshToken = jwtUtil.generateRefreshToken(member.getId());
+
+        log.info("Access Token 재발급 완료 - memberId: {}", memberId);
+
+        return JwtTokenResponse.of(
+                newAccessToken,
+                newRefreshToken,
+                jwtProperties.getAccessTokenValidity()
+        );
+    }
+}

--- a/backend/src/main/java/com/stay/domain/auth/util/JwtUtil.java
+++ b/backend/src/main/java/com/stay/domain/auth/util/JwtUtil.java
@@ -1,0 +1,167 @@
+package com.stay.domain.auth.util;
+
+import com.stay.config.JwtProperties;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SecurityException;
+import io.jsonwebtoken.JwtException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+/**
+ * JWT 토큰 생성 및 검증 유틸리티
+ *
+ * 왜 필요한가?
+ * - 로그인 성공 시 사용자를 식별할 수 있는 토큰을 만들어야 함
+ * - API 요청 시 토큰이 유효한지 검증해야 함
+ *
+ * JWT 구조:
+ * Header.Payload.Signature
+ * - Header: 토큰 타입, 알고리즘 정보
+ * - Payload: 실제 데이터 (memberId, email 등)
+ * - Signature: 위변조 방지용 서명
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtUtil {
+
+    private final JwtProperties jwtProperties;
+
+    /**
+     * JWT 서명에 사용할 비밀키 생성
+     * HS256 알고리즘 사용
+     */
+    private SecretKey getSigningKey() {
+        return Keys.hmacShaKeyFor(
+                jwtProperties.getSecret().getBytes(StandardCharsets.UTF_8)
+        );
+    }
+
+    // ==================== Access Token ====================
+
+    /**
+     * Access Token 생성
+     *
+     * @param memberId 회원 ID
+     * @param email 회원 이메일
+     * @return JWT Access Token
+     *
+     * 왜 memberId와 email을 넣을까?
+     * - memberId: DB 조회 시 사용 (성능)
+     * - email: 사용자 식별용 (가독성)
+     */
+    public String generateAccessToken(Long memberId, String email) {
+        Date now = new Date();
+        Date expiryDate = new Date(now.getTime() + jwtProperties.getAccessTokenValidity());
+
+        return Jwts.builder()
+                .subject(String.valueOf(memberId))           // 토큰 주체 (회원 ID)
+                .claim("email", email)                       // 추가 정보 (이메일)
+                .claim("type", "access")                     // 토큰 타입 구분
+                .issuedAt(now)                               // 발급 시간
+                .expiration(expiryDate)                      // 만료 시간
+                .signWith(getSigningKey())                   // 서명
+                .compact();
+    }
+
+    // ==================== Refresh Token ====================
+
+    /**
+     * Refresh Token 생성
+     * Access Token보다 유효기간이 길고, 최소한의 정보만 포함
+     *
+     * @param memberId 회원 ID
+     * @return JWT Refresh Token
+     */
+    public String generateRefreshToken(Long memberId) {
+        Date now = new Date();
+        Date expiryDate = new Date(now.getTime() + jwtProperties.getRefreshTokenValidity());
+
+        return Jwts.builder()
+                .subject(String.valueOf(memberId))
+                .claim("type", "refresh")
+                .issuedAt(now)
+                .expiration(expiryDate)
+                .signWith(getSigningKey())
+                .compact();
+    }
+
+    // ==================== 토큰 검증 ====================
+
+    /**
+     * 토큰에서 회원 ID 추출
+     *
+     * @param token JWT 토큰
+     * @return 회원 ID
+     * @throws JwtException 토큰이 유효하지 않은 경우
+     */
+    public Long getMemberIdFromToken(String token) {
+        Claims claims = parseClaims(token);
+        return Long.parseLong(claims.getSubject());
+    }
+
+    /**
+     * 토큰에서 이메일 추출
+     */
+    public String getEmailFromToken(String token) {
+        Claims claims = parseClaims(token);
+        return claims.get("email", String.class);
+    }
+
+    /**
+     * 토큰 유효성 검증
+     *
+     * @param token JWT 토큰
+     * @return 유효하면 true, 아니면 false
+     *
+     * 검증 내용:
+     * - 서명이 올바른가? (위변조 체크)
+     * - 만료되지 않았는가?
+     * - 형식이 올바른가?
+     */
+    public boolean validateToken(String token) {
+        try {
+            parseClaims(token);
+            return true;
+        } catch (SecurityException | MalformedJwtException e) {
+            log.error("잘못된 JWT 서명입니다.", e);
+        } catch (ExpiredJwtException e) {
+            log.error("만료된 JWT 토큰입니다.", e);
+        } catch (UnsupportedJwtException e) {
+            log.error("지원되지 않는 JWT 토큰입니다.", e);
+        } catch (IllegalArgumentException e) {
+            log.error("JWT 토큰이 잘못되었습니다.", e);
+        }
+        return false;
+    }
+
+    /**
+     * 토큰 파싱 (내부 사용)
+     * JWT를 해석해서 Payload(Claims)를 가져옴
+     */
+    private Claims parseClaims(String token) {
+        return Jwts.parser()
+                .verifyWith(getSigningKey())  // 서명 검증
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+
+    /**
+     * 토큰 타입 확인 (Access인지 Refresh인지)
+     */
+    public String getTokenType(String token) {
+        Claims claims = parseClaims(token);
+        return claims.get("type", String.class);
+    }
+}

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -13,3 +13,9 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQLDialect
+
+
+jwt:
+  secret: stay-secret-key-for-jwt-token-generation-at-least-256-bits-long-for-hs256-algorithm
+  access-token-validity: 3600000      # 1시간 (밀리초)
+  refresh-token-validity: 604800000   # 7일 (밀리초)


### PR DESCRIPTION
## 1단계: JWT 기본 설정
- JWT 라이브러리 추가 (jjwt 0.12.5)
- application-dev.yml에 JWT 설정 추가 (secret, validity)
- JwtProperties: JWT 설정을 읽어오는 Properties 클래스
- JwtUtil: JWT 생성/검증 유틸리티 클래스
  - generateAccessToken(): Access Token 생성 (1시간)
  - generateRefreshToken(): Refresh Token 생성 (7일)
  - validateToken(): 토큰 유효성 검증
  - getMemberIdFromToken(): 토큰에서 회원 ID 추출

## 2단계: Auth 도메인 구현
- AuthService: 인증 비즈니스 로직
  - socialLogin(): 소셜 로그인 처리 및 JWT 발급
  - refreshAccessToken(): Access Token 재발급
- AuthController: 인증 API 엔드포인트
  - POST /api/auth/login: 소셜 로그인
  - POST /api/auth/refresh: 토큰 재발급
- JwtTokenResponse: JWT 응답 DTO (Record)
- TokenRefreshRequest: 토큰 재발급 요청 DTO (Record)

## 트랜잭션 전략
- AuthService: 클래스 레벨 readOnly 제거
  - socialLogin(): MemberService에서 트랜잭션 관리
  - refreshAccessToken(): 읽기 전용 트랜잭션 적용

## 테스트
- auth-test.http: API 테스트용 HTTP 파일 추가