### PR TITLE
feat: OAuth 회원가입 시 트랜잭션 분리 및 회원가입 플로우 개선

### DIFF
--- a/backend/src/main/java/com/stay/domain/auth/dto/JwtTokenResponse.java
+++ b/backend/src/main/java/com/stay/domain/auth/dto/JwtTokenResponse.java
@@ -19,13 +19,15 @@ public record JwtTokenResponse(
         String tokenType,
         Long expiresIn,
         boolean isNewMember,
-        String email
+        String email,
+        String provider,
+        String providerId,
+        String name,
+        String profileImageUrl
 ) {
     /**
-     * 편의 생성 메서드
-     * Bearer 타입으로 고정하고, 만료 시간을 자동 계산
-     *
-     * 5개 파라미터 버전 (신규 회원 포함)
+     * 기존 회원용 생성 메서드
+     * (토큰 포함, OAuth 정보 없음)
      */
     public static JwtTokenResponse of(
             String accessToken,
@@ -40,7 +42,36 @@ public record JwtTokenResponse(
                 "Bearer",
                 accessTokenValidity / 1000,  // 밀리초 -> 초 변환
                 isNewMember,
-                email
+                email,
+                null,
+                null,
+                null,
+                null
+        );
+    }
+
+    /**
+     * 신규 회원용 생성 메서드
+     * (토큰 없음, OAuth 정보 포함)
+     */
+    public static JwtTokenResponse ofNewMember(
+            String email,
+            String provider,
+            String providerId,
+            String name,
+            String profileImageUrl
+    ) {
+        return new JwtTokenResponse(
+                null,  // 토큰 없음
+                null,
+                "Bearer",
+                null,
+                true,  // 신규 회원
+                email,
+                provider,
+                providerId,
+                name,
+                profileImageUrl
         );
     }
 
@@ -60,8 +91,12 @@ public record JwtTokenResponse(
                 refreshToken,
                 "Bearer",
                 accessTokenValidity / 1000,
-                false,  // 기본값: 기존 회원
-                null    // 이메일 없음
+                false,
+                null,
+                null,
+                null,
+                null,
+                null
         );
     }
 }

--- a/backend/src/main/java/com/stay/domain/auth/service/OAuthService.java
+++ b/backend/src/main/java/com/stay/domain/auth/service/OAuthService.java
@@ -178,7 +178,8 @@ public class OAuthService {
                 userInfo.email(),
                 userInfo.name(),
                 userInfo.email(),
-                userInfo.picture()
+                userInfo.picture(),
+                null
         );
     }
 
@@ -207,7 +208,8 @@ public class OAuthService {
                 userInfo.email(),
                 userInfo.name(),
                 userInfo.email(),
-                userInfo.profile_image()
+                userInfo.profile_image(),
+                null
         );
     }
 
@@ -244,7 +246,9 @@ public class OAuthService {
                 email,
                 name,
                 userInfo.kakao_account().email(),
-                profileImage
+                profileImage,
+                null
+
         );
     }
 }

--- a/backend/src/main/java/com/stay/domain/member/dto/SocialLoginRequest.java
+++ b/backend/src/main/java/com/stay/domain/member/dto/SocialLoginRequest.java
@@ -12,7 +12,8 @@ public record SocialLoginRequest(
         String email,
         String name,
         String socialEmail,
-        String profileImageUrl
+        String profileImageUrl,
+        String nickname
 ) {
 
     /**
@@ -34,6 +35,10 @@ public record SocialLoginRequest(
 
         if (profileImageUrl != null) {
             profileImageUrl = profileImageUrl.trim();
+        }
+
+        if (nickname != null) {
+            nickname = nickname.trim();
         }
     }
 }

--- a/backend/src/main/resources/db/migration/V3__add_nickname_column.sql
+++ b/backend/src/main/resources/db/migration/V3__add_nickname_column.sql
@@ -19,7 +19,3 @@ SET nickname = CONCAT(
     member_id                         -- 회원 ID (고유성 보장)
 )
 WHERE nickname IS NULL;
-
--- 4. 이제 닉네임을 필수로 변경
-ALTER TABLE members
-MODIFY COLUMN nickname VARCHAR(30) NOT NULL COMMENT '사용자 닉네임 (고유, 필수)';

--- a/backend/src/main/resources/db/migration/V6__modify_password_nullable.sql
+++ b/backend/src/main/resources/db/migration/V6__modify_password_nullable.sql
@@ -1,0 +1,13 @@
+-- V6: members 테이블의 password 컬럼을 nullable로 변경
+--
+-- 변경 이유:
+-- 1. 소셜 로그인 사용자는 비밀번호가 필요없음
+-- 2. 일반 회원가입 사용자만 비밀번호 필요
+-- 3. 두 가지 가입 방식을 모두 지원하기 위해 password를 선택 필드로 변경
+
+-- password 컬럼을 NULL 허용으로 변경
+ALTER TABLE members
+    ADD COLUMN password VARCHAR(255) NULL COMMENT '비밀번호 (소셜 로그인 시 NULL)'
+    AFTER email;
+
+-- 마이그레이션 완료 로그

--- a/frontend/src/lib/api/authApi.js
+++ b/frontend/src/lib/api/authApi.js
@@ -120,5 +120,69 @@ const authApi = {
       );
     }
   },
+
+  /**
+   * OAuth 최종 회원가입 (닉네임 포함)
+   *
+   * POST /api/auth/oauth/register
+   *
+   * 왜 필요한가?
+   * - OAuth 인증 후 닉네임까지 입력받아서 한 번에 회원가입 완료
+   * - 251102 문제인 소셜 회원가입시 생기는 DB에 null값인 닉네임을 저장하려는 문제를 해결함
+   * - nickname=NULL 레코드 생기지 않음
+   *
+   * @param {Object} data - OAuth 정보 + 닉네임
+   * @param {string} data.provider - 소셜 제공자 (GOOGLE, NAVER, KAKAO)
+   * @param {string} data.providerId - 소셜 고유 ID
+   * @param {string} data.email - 이메일
+   * @param {string} data.name - 이름
+   * @param {string} data.nickname - 닉네임
+   * @param {string} [data.profileImageUrl] - 프로필 이미지 (선택)
+   * @returns {Promise<Object>} 회원가입 성공 응답
+   */
+  registerWithOAuth: async (data) => {
+    try {
+      console.log("========================================");
+      console.log("OAuth 최종 회원가입 API 호출");
+      console.log("Provider:", data.provider);
+      console.log("Email:", data.email);
+      console.log("Nickname:", data.nickname);
+      console.log("========================================");
+
+      // 백엔드 형식에 맞게 데이터 변환
+      const requestData = {
+        provider: data.provider,
+        socialId: data.providerId, // ← providerId → socialId
+        email: data.email,
+        name: data.name,
+        socialEmail: data.email, // ← socialEmail 추가
+        profileImageUrl: data.profileImageUrl || null,
+        nickname: data.nickname,
+      };
+
+      console.log("변환된 요청 데이터:", requestData);
+
+      const response = await apiClient.post(
+        "/auth/oauth/register",
+        requestData
+      );
+
+      console.log("OAuth 최종 회원가입 API 응답:", response.data);
+
+      if (!response.data.success) {
+        throw new Error(response.data.message || "회원가입에 실패했습니다");
+      }
+
+      return response.data;
+    } catch (error) {
+      console.error("OAuth 최종 회원가입 API 실패:", error);
+
+      if (error.response?.data?.message) {
+        throw new Error(error.response.data.message);
+      }
+
+      throw new Error("회원가입 처리 중 오류가 발생했습니다");
+    }
+  },
 };
 export default authApi;

--- a/frontend/src/pages/OAuthCallback.jsx
+++ b/frontend/src/pages/OAuthCallback.jsx
@@ -56,13 +56,19 @@ export default function OAuthCallback() {
 
         // 신규 회원인 경우 회원가입 페이지로 이동
         if (result.isNewMember === true) {
-          console.log("신규 회원 감지 - 회원가입 페이지로 이동");
+          console.log("신규 회원 감지 - OAuth 정보를 sessionStorage에 저장");
+
+          // sessionStorage에 OAuth 정보 저장
+          sessionStorage.setItem("oauthData", JSON.stringify(result.oauthData));
+
+          console.log("OAuth Data 저장 완료:", result.oauthData);
+
           setTimeout(() => {
             navigate("/signup", {
               replace: true,
               state: {
                 fromOAuth: true,
-                email: result.email,
+                isNewMember: true,
               },
             });
           }, UI_DELAY.REDIRECT);


### PR DESCRIPTION
**기존 방식의 문제:**
- OAuth 로그인 시 AuthService에서 즉시 회원가입 처리 (socialLogin() 호출)
- 닉네임 없이 DB에 먼저 저장 (nickname=NULL)
- 이후 닉네임 설정 API를 별도로 호출
- 트랜잭션이 분리되어 nickname=NULL 상태가 DB에 영구 저장될 위험

**개선된 방식:**
- OAuth 인증과 회원가입 로직을 완전히 분리
- 신규 회원 감지 시 DB 저장 없이 OAuth 정보만 프론트로 반환
- 프론트에서 닉네임 입력 후 최종 가입 API 호출
- 닉네임을 포함한 완전한 데이터로 단일 트랜잭션에서 회원가입 완료
- 데이터 무결성 보장 및 불완전한 회원 데이터 생성 방지

## 변경 사항

### 백엔드
- JwtTokenResponse에 OAuth 정보 필드 추가 (provider, providerId, name, profileImageUrl)
- JwtTokenResponse.ofNewMember() 메서드 추가 (신규 회원용)
- OAuthController에 registerWithOAuth() API 추가 (POST /api/auth/oauth/register)
- AuthService.oauthLogin() 수정: 신규 회원은 OAuth 정보만 반환, 바로 DB에 저장 안 함
- AuthService.registerWithOAuth() 메서드 추가: 닉네임 포함 최종 가입 처리
- SocialLoginRequest에 nickname 필드 추가
- OAuthService: 각 소셜 로그인 메서드에서 nickname을 null로 반환하도록 수정
- MemberService.registerSocialMember()에 닉네임 중복 체크 추가
- MemberService에 existsByNickname(), existsByEmail() 메서드 추가

### 프론트엔드
- OAuthCallback: 신규 회원 시 OAuth 정보를 sessionStorage에 저장
- UserInfoStep: sessionStorage에서 OAuth 정보 로드 후 최종 가입 API 호출
- authApi.registerWithOAuth() 메서드 추가: providerId를 socialId로 변환하여 전송

### 데이터베이스
- V3 마이그레이션 수정: nickname 컬럼을 NULL 허용으로 유지 (NOT NULL 변경 제거)
- V6 마이그레이션 추가: password 컬럼 추가 (NULL 허용, 소셜 로그인 대응)

## 플로우
1. 사용자가 OAuth 로그인 → 백엔드에서 신규 회원 확인
2. 신규 회원이면 OAuth 정보를 sessionStorage에 저장
3. 회원가입 페이지(step=3)로 이동하여 닉네임 입력
4. 닉네임 + OAuth 정보로 최종 가입 API 호출
5. 회원가입 완료 후 자동 로그인 (쿠키 발급)

## 해결된 문제
- OAuth 로그인 시 nickname=NULL로 DB에 저장되던 문제 해결
- 소셜 로그인과 일반 로그인의 회원가입 플로우 분리
- 닉네임 중복 체크 강화