### PR TITLE
fix: 회원가입 후 사용자 정보 조회하여 닉네임에 즉시 표시

### DIFF
--- a/frontend/src/components/auth/UserInfoStep.jsx
+++ b/frontend/src/components/auth/UserInfoStep.jsx
@@ -135,8 +135,18 @@ export default function UserInfoStep({ onNext }) {
       // sessionStorage에서 OAuth 정보 삭제
       sessionStorage.removeItem("oauthData");
 
-      // 로그인 상태 업데이트 (쿠키에서 자동으로 토큰 가져옴)
-      await login();
+      console.log("사용자 정보 조회 시작...");
+      try {
+        const userData = await authApi.getCurrentUser();
+        console.log("사용자 정보 조회 성공:", userData);
+
+        // AuthContext에 저장
+        await login(userData); // ← userData를 전달!
+      } catch (err) {
+        console.error("사용자 정보 조회 실패:", err);
+        // 최소한의 정보로라도 로그인 처리
+        await login({ email: oauthData.email, nickname: formData.nickname });
+      }
 
       console.log("로그인 상태 업데이트 완료");
       console.log("회원가입 완료 - 4단계로 이동");


### PR DESCRIPTION
UserInfoStep에서 회원가입 완료 후  login() 함수 호출 할 때 사용자 정보를 전달하지 않고 있어서 정보 조회 후 로그인하도록 수정.

- login() 함수에 닉네임 포함한 사용자 정보 전달