### PR TITLE
fix: 12세 아동이 URL에 누락되는 문제 수정

### DIFF
--- a/frontend/src/hooks/useHomeSearchState.js
+++ b/frontend/src/hooks/useHomeSearchState.js
@@ -26,7 +26,7 @@ export default function useHomeSearchState(init = {}) {
       // 아동 수 증가: 새로운 아동 연령 추가 (기본값: 빈 문자열)
       const newAges = [...childrenAges];
       while (newAges.length < childCount) {
-        newAges.push("");
+        newAges.push("12");
       }
       setChildrenAges(newAges);
     } else if (childCount < childrenAges.length) {


### PR DESCRIPTION
- 아동 연령 배열 초기화 시 빈 문자열 대신 "12" 기본값 설정
- BookingPopover에서 기본값 "12"로 표시되지만 실제 배열에는 빈 문자열이 저장되어 필터링에서 제거되던 문제 해결
- 12세 아동 정보가 URL 파라미터에 정상 반영되도록 수정