### PR TITLE
fix: Home/Login 페이지 코드 품질 개선

### DIFF
--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -7,6 +7,7 @@ import useHomeSearchState from "@hooks/useHomeSearchState";
 import SearchForm from "@search/SearchForm";
 
 export default function Home() {
+  // nav→navigate, s→searchState, go→handleSearchSubmit, p→payload
   const categories = ["국내 숙소", "해외 숙소"];
   const [active, setActive] = useState("국내 숙소");
   const nav = useNavigate();
@@ -46,7 +47,8 @@ export default function Home() {
                 {/* 국내 해외 선택 */}
                 <div className="mb-3 flex flex-wrap">
                   {categories.map((cat) => (
-                    <span
+                    <button
+                      type="button"
                       key={cat}
                       onClick={() => setActive(cat)}
                       className={`text-base md:text-lg p-2 cursor-pointer mb-1 ${
@@ -56,7 +58,7 @@ export default function Home() {
                       }`}
                     >
                       {cat}
-                    </span>
+                    </button>
                   ))}
                 </div>
                 <SearchForm

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -16,14 +16,12 @@ export default function Login() {
         </div>
         <SocialLoginButtons demo={false} />
         <div className="flex center justify-center">
-          <a>
-            <Link
-              to="/business/Login"
-              className="inline-flex items-center justify-center gap-2 hover:bg-gray-100 transition-colors cursor-pointer font-semibold text-slate-700 rounded-md px-2 py-1"
-            >
-              비즈니스 회원으로 시작하기
-            </Link>
-          </a>
+          <Link
+            to="/business/login"
+            className="inline-flex items-center justify-center gap-2 hover:bg-gray-100 transition-colors cursor-pointer font-semibold text-slate-700 rounded-md px-2 py-1"
+          >
+            비즈니스 회원으로 시작하기
+          </Link>
         </div>
       </div>
     </section>


### PR DESCRIPTION
- Login: a 태그 안에 Link 중첩되어 있던 잘못된 마크업 제거
- Login: /business/Login 경로를 라우터 등록값과 동일하게 소문자로 통일 (React Router는 path 대소문자를 기본적으로 구분하지 않아 동작에는 문제없었으나, sensitive 옵션 사용 시 깨질 수 있어 컨벤션 통일)
- Home: 카테고리 탭(국내/해외 숙소)을 span에서 button으로 변경 → 키보드 포커스 불가, 스크린리더 인식 불가 문제 해결
- Home: 축약 변수명(nav, s, go, p)에 의미를 설명하는 주석 추가